### PR TITLE
Bind the argument of `dynamodbRecord()` to the transformed immediately invoked function's parameter

### DIFF
--- a/tests/transformer.test.ts
+++ b/tests/transformer.test.ts
@@ -280,9 +280,9 @@ describe('dynamodb record transform', () => {
         ['buz', 'qux'],
       ]),
     });
+    expect(record['id']).toEqual({ N: '12345' });
     expect(record['name']).toEqual({ S: 'John Doe' });
     expect(record['tags']).toEqual({ M: { foo: { S: 'bar' }, buz: { S: 'qux' } } });
-    expect(record['id']).toEqual({ N: '12345' });
     expect(Object.keys(record)).toHaveLength(3);
   });
 });

--- a/transformer.ts
+++ b/transformer.ts
@@ -246,11 +246,11 @@ function visitNode(node: ts.Node, program: ts.Program): ts.Node | undefined {
     })
     .filter((c): c is ts.ObjectLiteralElementLike => !!c);
 
-  return ts.factory.createImmediatelyInvokedFunctionExpression([
-    ts.factory.createVariableStatement([], [ts.factory.createVariableDeclaration(argVarNameIdent)]),
-    ts.factory.createBinaryExpression(argVarNameIdent, ts.SyntaxKind.EqualsToken, node.arguments[0]),
-    ts.factory.createReturnStatement(ts.factory.createObjectLiteralExpression(objectProps, true)),
-  ] as ts.Statement[]);
+  return ts.factory.createImmediatelyInvokedFunctionExpression(
+    [ts.factory.createReturnStatement(ts.factory.createObjectLiteralExpression(objectProps, true))] as ts.Statement[],
+    ts.factory.createParameterDeclaration([], undefined, argVarNameIdent, undefined, node.typeArguments[0], undefined),
+    node.arguments[0],
+  );
 }
 
 function extractKeyValueTypesFromKeyValuePairMapSyntax(nodes: ts.Node[]): [string, string] | undefined {


### PR DESCRIPTION
For example, when the original TypeScript code is the following:

```ts
dynamodbRecord(foo);
```

before this commit, it generates the code like the following:

```js
function () {
    var arg;
    arg = foo;
    ...
}();
```

this commit makes it generate as the following:

```js
function (arg) {
    ...
}(foo);
```