### PR TITLE
Change the return type's key type parameter of `dynamodbRecord()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Code transformer plugin for Amazon DynamoDB attributes powered by [TypeScript Co
 
 ## How it works
 
-This plugin replaces the TypeScript function invocation of `dynamodbRecord<T>(obj: T)` with `Record<string, AttributeValue>` value that is defined in aws-sdk-js-v3 according to the type `T` and the contents of the object. In short, this plugin generates the DynamoDB attribute code for every property of type `T`.
+This plugin replaces the TypeScript function invocation of `dynamodbRecord<T>(obj: T)` with `Record<keyof T, AttributeValue>` value that is defined in aws-sdk-js-v3 according to the type `T` and the contents of the object. In short, this plugin generates the DynamoDB attribute code for every property of type `T`.
 
-This plugin powers the users can do drop-in replacements for the existing `Record<string, AttributeValue>` value and/or the generator with `dynamodbRecord<T>(obj: T)` function.
+This plugin powers the users can do drop-in replacements for the existing `Record<keyof T, AttributeValue>` value and/or the generator with `dynamodbRecord<T>(obj: T)` function.
 
 Manual making the translation layer between the object and DynamoDB's Record is no longer needed!
 
@@ -27,7 +27,7 @@ interface User {
   readonly tags: Map<string, string>;
 }
 
-const record: Record<string, AttributeValue> = dynamodbRecord<User>({
+const record: Record<keyof User, AttributeValue> = dynamodbRecord<User>({
   id: 12345,
   name: 'John Doe',
   tags: new Map<string, string>([
@@ -38,7 +38,7 @@ const record: Record<string, AttributeValue> = dynamodbRecord<User>({
 
 /*
  * Then you can use this record value on the aws-sdk-js-v3's DynamoDB client; for example,
- * 
+ *
  *   const dyn = new DynamoDBClient(...);
  *   await dyn.send(new PutItemCommand({
  *     TableName: "...",
@@ -81,7 +81,7 @@ const record = function () {
 }();
 /*
  * This record is equal to the following object:
- * 
+ *
  *   {
  *     id: { N: "12345" },
  *     name: { S: "John Doe" },
@@ -97,11 +97,11 @@ const record = function () {
 
 ## How to use this transformer
 
-This plugin exports a function that has the signature `dynamodbRecord<T extends object>(item: T): Record<string, AttributeValue>`.
+This plugin exports a function that has the signature `dynamodbRecord<T extends object>(item: T): Record<keyof T, AttributeValue>`.
 
-This function is a marker to indicate to the transformer to replace this function invocation with the generated DynamoDB record code. Therefore, there are some restrictions: 
+This function is a marker to indicate to the transformer to replace this function invocation with the generated DynamoDB record code. Therefore, there are some restrictions:
 
-- Type parameter `T` is mandatory parameter (i.e. this mustn't be omitted). A transformer analyzes the type of the given `T` to collect the property information. 
+- Type parameter `T` is mandatory parameter (i.e. this mustn't be omitted). A transformer analyzes the type of the given `T` to collect the property information.
 - Type `T` must be class or interface.
 
 ### Examples

--- a/examples/ttypescript/index.ts
+++ b/examples/ttypescript/index.ts
@@ -7,7 +7,7 @@ interface User {
   readonly tags: Map<string, string>;
 }
 
-const record: Record<string, AttributeValue> = dynamodbRecord<User>({
+const record: Record<keyof User, AttributeValue> = dynamodbRecord<User>({
   id: 12345,
   name: 'John Doe',
   tags: new Map<string, string>([

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
 import { AttributeValue } from '@aws-sdk/client-dynamodb';
 
-export function dynamodbRecord<T extends object>(item: T): Record<string, AttributeValue>;
+export function dynamodbRecord<T extends object>(item: T): Record<keyof T, AttributeValue>;

--- a/tests/transformer.test.ts
+++ b/tests/transformer.test.ts
@@ -30,7 +30,7 @@ describe('dynamodb record transform', () => {
       ) {}
     }
 
-    const record: Record<string, AttributeValue> = dynamodbRecord<Clazz>(
+    const record: Record<keyof Clazz, AttributeValue> = dynamodbRecord<Clazz>(
       new Clazz(
         123,
         234,
@@ -201,7 +201,7 @@ describe('dynamodb record transform', () => {
       constructor(private privateString: string, justArgument: string) {}
     }
 
-    const record: Record<string, AttributeValue> = dynamodbRecord<Clazz>(new Clazz('foo', 'bar'));
+    const record: Record<keyof Clazz, AttributeValue> = dynamodbRecord<Clazz>(new Clazz('foo', 'bar'));
     expect(Object.keys(record)).toHaveLength(0);
   });
 
@@ -220,7 +220,7 @@ describe('dynamodb record transform', () => {
       ) {}
     }
 
-    const record: Record<string, AttributeValue> = dynamodbRecord<Clazz>(
+    const record: Record<keyof Clazz, AttributeValue> = dynamodbRecord<Clazz>(
       new Clazz(
         /re/,
         [/re/],
@@ -247,7 +247,7 @@ describe('dynamodb record transform', () => {
         readonly kvMapToBigint: { [key: string]: BigInt },
       ) {}
     }
-    const record: Record<string, AttributeValue> = dynamodbRecord<Clazz>(
+    const record: Record<keyof Clazz, AttributeValue> = dynamodbRecord<Clazz>(
       new Clazz(
         BigInt(123),
         [BigInt(123), BigInt(234)],
@@ -272,7 +272,7 @@ describe('dynamodb record transform', () => {
       readonly name: string;
       readonly tags: Map<string, string>;
     }
-    const record: Record<string, AttributeValue> = dynamodbRecord<Interface>({
+    const record: Record<keyof Interface, AttributeValue> = dynamodbRecord<Interface>({
       id: 12345,
       name: 'John Doe',
       tags: new Map<string, string>([


### PR DESCRIPTION
It changes returning the `keyof T` instead of `string` for the key type of `Record`.